### PR TITLE
Rudimentry plugin upload and download

### DIFF
--- a/endless-sky.html
+++ b/endless-sky.html
@@ -153,7 +153,9 @@
         </div>
       </div>
       <button class="load-button" disabled>Play</button>
-      <h2 class="plugins-header" style="display: none;">Plugins</h2>
+      <h2 class="plugin-editor-header" style="display: none;">Upload Plugins</h2>
+      <div class="plugin-editor-upload"></div>
+      <h2 class="external-plugins-header" style="display: none;">Published Plugins</h2>
       <div class="plugins-list">Plugins</div>
     </div>
     <div class="debug">
@@ -353,16 +355,19 @@
         }
         await idbReady();
 
-        const showPluginManager = (new URL(location)).searchParams.has('plugins');
+        const showRemotePlugins = (new URL(location)).searchParams.has('plugins');
 
         let loadButtonResolve
         const loadButtonPromise = new Promise((r) => loadButtonResolve = r);
         const loadButton = document.querySelector('.load-button');
 
-        if (showPluginManager) {
+        const pluginEditor = true; // this is the the editor
+        if (showRemotePlugins || pluginEditor) {
           loadButton.disabled = false;
           loadButton.addEventListener("click", loadButtonResolve);
         } else {
+          // just load immediately
+          loadButtonResolve();
           loadButton.style.display = 'none';
         }
 
@@ -375,14 +380,30 @@
         await addMainScriptTag(data);
         await runtimeInitializedPromise;
 
-        if (showPluginManager) {
-          document.querySelector('.plugins-header').style.display = '';
-          const plugins = await (await fetch("https://raw.githubusercontent.com/EndlessSkyCommunity/endless-sky-plugins/master/generated/plugins.json")).json()
-          showPlugins(document.querySelector('.plugins-list'), plugins);
-          FS.mkdir('plugins');
+        FS.mkdir('plugins');
+        if (showRemotePlugins) {
+          let remotePlugins;
+          // catch mostly for offline dev
+          try {
+            remotePlugins = await (await fetch("https://raw.githubusercontent.com/EndlessSkyCommunity/endless-sky-plugins/master/generated/plugins.json")).json();
+          } catch (e) {
+            window.foo = e;
+            if (e instanceof TypeError && e.message === 'Failed to fetch') {
+              console.log("maybe the GitHub plugins link is broken, but more likely you're offline");
+              // TODO check connection status?
+            } else throw e;
+          }
 
-          await loadButtonPromise
+          if (remotePlugins) {
+            document.querySelector('.external-plugins-header').style.display = '';
+            showPlugins(document.querySelector('.plugins-list'), remotePlugins);
+          }
         }
+        if (pluginEditor) {
+            document.querySelector('.plugin-editor-header').style.display = '';
+            showPluginUpload(document.querySelector('.plugin-editor-upload'));
+        }
+        await loadButtonPromise;
         loadButton.disabled = true;
         document.querySelector('.loading').style.zIndex = -1;
         Module.callMain([]);

--- a/endless-sky.html
+++ b/endless-sky.html
@@ -164,6 +164,8 @@
       <button onclick="document.querySelector('.file-selector').click();" />upload saved game</button>
       <button class="show-save-games">Show save game files for download</button>
       <div class="save-games"></div>
+      <button class="show-plugins-to-download">Show plugins for download</button>
+      <div class="plugins-to-download"></div>
       <input type="file" style="display: none;" class="file-selector" multiple="multiple">
       <div class="status">Status goes here</div>
       <textarea id="output" rows="8">stdout output goes here</textarea>
@@ -229,6 +231,9 @@
       const saveGamesList = document.querySelector('.save-games');
       const showSaveGamesButton = document.querySelector('.show-save-games');
       showSaveGamesButton.addEventListener('click', () => showSaveGames(saveGamesList));
+      const pluginsToDownloadList = document.querySelector('.plugins-to-download');
+      const pluginsToDownloadButton = document.querySelector('.show-plugins-to-download');
+      pluginsToDownloadButton.addEventListener('click', () => showPluginsForDownload(pluginsToDownloadList));
 
       const progressBar = document.querySelector('.progressBar');
       const progress = document.querySelector('.progress');
@@ -381,6 +386,7 @@
         await runtimeInitializedPromise;
 
         FS.mkdir('plugins');
+        FS.mkdir('saves');
         if (showRemotePlugins) {
           let remotePlugins;
           // catch mostly for offline dev

--- a/js/cached-resource.js
+++ b/js/cached-resource.js
@@ -48,6 +48,7 @@
   // Caches a single version of a resource
   class CachedResource {
     constructor(resourceUrl, keySuffix) {
+      if (keySuffix === undefined) keySuffix = "";
       this.resourceUrl = resourceUrl;
       this.cacheKey = resourceUrl + keySuffix;
     }
@@ -56,12 +57,22 @@
       const cachedVersion = await kvstore.get(this.cacheKey + "-version");
       if (cachedData) {
         if (version === cachedVersion) {
-          console.log("Using cached resource", this.resourceUrl);
+          console.log(
+            "Using cached resource",
+            this.cacheKey,
+            "originally downloaded from",
+            this.resourceUrl
+          );
           progressCallback(cachedData.byteLength, cachedData.byteLength, true);
           console.log("cached data:", cachedData);
           return cachedData;
         }
-        console.log("Out of date resource, redownloading", this.resourceUrl);
+        console.log(
+          "Out of date resource",
+          this.cacheKey,
+          "so redownloading",
+          this.resourceUrl
+        );
         console.log(
           "required version",
           version,


### PR DESCRIPTION
Upload plugins via drag and drop or file upload dialog (only possible before Endless Sky proper starts) and download plugins as zipfiles.

I can put this up at https://play-endless-web.com/editor this evening when I'm not ✈️.

Not included:
- better plugin download UI / file manager UI
- uploading zipfiles
- preserve empty directories (like with git, these currently disappear on upload)
- automatically downloading on Save All or popping a download prompt on Save All
- preserving file modification dates
- check that round-tripping works for non-trivial plugins, checking both upload codepaths
- try on Windows
