### PR TITLE
Don't create /saves if it already exists

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -72,7 +72,11 @@ void InitConsole();
 int main(int argc, char *argv[])
 {
 #ifdef __EMSCRIPTEN__
-	EM_ASM(FS.mkdir('/saves');
+	EM_ASM(
+	if (!FS.analyzePath('/saves').exists) {
+		// may have already been created for uploading
+		FS.mkdir('/saves');
+	}
 	FS.mount(IDBFS, {}, '/saves');
 
 	// sync from persisted state into memory


### PR DESCRIPTION
an oversight because I didn't test actually starting the game after adding mkdir('/saves') so that save games were accessible without starting the game.